### PR TITLE
bugfix: fix nonce validation

### DIFF
--- a/debridge_node/package-lock.json
+++ b/debridge_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debridge_node",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debridge_node",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bundlr-network/client": "0.10.5",

--- a/debridge_node/package.json
+++ b/debridge_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debridge_node",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "",
   "author": "debridge-finance",
   "private": true,

--- a/debridge_node/src/modules/chain/scanning/services/SubmissionProcessingService.ts
+++ b/debridge_node/src/modules/chain/scanning/services/SubmissionProcessingService.ts
@@ -90,7 +90,6 @@ export class SubmissionProcessingService {
       if (submissionInDb) {
         logger.verbose(`Submission already found in db submissionId: ${submissionId}`);
         blockOrTransactionToOverwrite = this.getBlockNumberOrTransaction(submissionInDb);
-        this.nonceControllingService.setMaxNonce(chainIdFrom, submissionInDb.nonce);
         continue;
       }
 


### PR DESCRIPTION
What?
Don't change max nonce If submission was exists in db
Why?
It invokes a problem if solana reader returns "old" nonce.
Example:
1) max nonce in db = 10
2) solana reader returns submission with nonces 7, 11, 12
3) change max nonce to 7
4) max nonce + 1 = 8 != 11
5) can't process new events in chain