### PR TITLE
validate config maxBlockRange > 50

### DIFF
--- a/debridge_node/package-lock.json
+++ b/debridge_node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "debridge_node",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/debridge_node/package.json
+++ b/debridge_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debridge_node",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "",
   "author": "debridge-finance",
   "private": true,

--- a/debridge_node/src/modules/jobs/services/StartScanningService.ts
+++ b/debridge_node/src/modules/jobs/services/StartScanningService.ts
@@ -47,8 +47,8 @@ export class StartScanningService implements OnModuleInit {
         continue;
       }
       const chainConfigEvm = chainConfig as EvmChainConfig;
-      if (chainConfigEvm.maxBlockRange <= 100) {
-        this.logger.error(`Cant up application maxBlockRange(${chainConfigEvm.maxBlockRange}) < 100`);
+      if (chainConfigEvm.maxBlockRange < 50) {
+        this.logger.error(`Cant up application maxBlockRange(${chainConfigEvm.maxBlockRange}) < 50`);
         process.exit(1);
       }
       if (chainConfigEvm.blockConfirmation <= 8) {


### PR DESCRIPTION
The maxBlockRange validation threshold has been reduced to 50.
There are networks where the max range in the RPC is set to 100 blocks.