### PR TITLE
Fix Block Scanning Reliability with Incorrect RPC Latest Block

### DIFF
--- a/debridge_node/package-lock.json
+++ b/debridge_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debridge_node",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debridge_node",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "BUSL-1.1",
       "dependencies": {
         "@bundlr-network/client": "0.10.5",

--- a/debridge_node/package.json
+++ b/debridge_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debridge_node",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "",
   "author": "debridge-finance",
   "private": true,


### PR DESCRIPTION
This PR resolves issues with block scanning when the RPC returns an incorrect latest block number, including cases where the reported block exceeds the actual latest block. It ensures reliable scanning by:

- Resetting the starting block (fromBlock) on the next job scan to the block number of the latest sendEvent stored in the database, overriding the previous starting block for consistency.

