### PR TITLE
fix: prevent massive resyncs when RPC returns stale block number

### DIFF
--- a/debridge_node/src/modules/chain/scanning/services/AddNewEventsAction.ts
+++ b/debridge_node/src/modules/chain/scanning/services/AddNewEventsAction.ts
@@ -11,7 +11,6 @@ import { SubmissionProcessingService } from './SubmissionProcessingService';
 import { TransformService } from './TransformService';
 import { ProcessNewTransferResultStatusEnum } from '../enums/ProcessNewTransferResultStatusEnum';
 import Contract from 'web3-eth-contract';
-import { SubmissionEntity } from 'src/entities/SubmissionEntity';
 
 @Injectable()
 export class AddNewEventsAction {
@@ -21,8 +20,6 @@ export class AddNewEventsAction {
   constructor(
     @InjectRepository(SupportedChainEntity)
     private readonly supportedChainRepository: Repository<SupportedChainEntity>,
-    @InjectRepository(SubmissionEntity)
-    private readonly submissionsRepository: Repository<SubmissionEntity>,
     private readonly chainConfigService: ChainConfigService,
     private readonly web3Service: Web3Service,
     private readonly solanaReaderService: SolanaReaderService,
@@ -76,24 +73,14 @@ export class AddNewEventsAction {
     logger.debug(`Getting events from block ${fromBlock} to ${toBlock} on ${supportedChain.network}`);
 
     // Handle invalid block range (fromBlock > toBlock)
+    // This can happen when the RPC returns a stale block number due to load balancing,
+    // network issues, or node sync delays. We reset to toBlock to prevent massive resyncs.
     if (fromBlock > toBlock) {
-      logger.error(`Invalid block range: fromBlock (${fromBlock}) > toBlock (${toBlock})`);
-
-      // Find the latest block number for the given chainId from the submissions repository
-      const lastEvent = await this.submissionsRepository.findOne({
-        where: { chainFrom: chainId },
-        order: { blockNumber: 'DESC' }, // Get the highest block number
-      });
-
-      const newLatestBlock = lastEvent?.blockNumber ?? toBlock;
-      if (!lastEvent) {
-        logger.warn(`No events found for chainId ${chainId}. Using toBlock (${toBlock}) as latest.`);
-      } else {
-        logger.debug(`Found last event block number: ${newLatestBlock} for chainId ${chainId}`);
-      }
-
-      await this.supportedChainRepository.update(chainId, { latestBlock: newLatestBlock });
-      logger.log(`Updated latestBlock for chainId ${chainId} to ${newLatestBlock}`);
+      logger.warn(
+        `Stale RPC response detected: fromBlock (${fromBlock}) > toBlock (${toBlock}). ` +
+        `Resetting latestBlock to ${toBlock} to prevent resync from old blocks.`
+      );
+      await this.supportedChainRepository.update(chainId, { latestBlock: toBlock });
       return;
     }
 

--- a/debridge_node/src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts
+++ b/debridge_node/src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts
@@ -4,7 +4,6 @@ import { Web3Service } from '../../../../web3/services/Web3Service';
 import { SolanaReaderService } from '../SolanaReaderService';
 import { SubmissionProcessingService } from '../SubmissionProcessingService';
 import { TransformService } from '../TransformService';
-import { SubmissionEntity } from '../../../../../entities/SubmissionEntity';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SupportedChainEntity } from '../../../../../entities/SupportedChainEntity';
@@ -51,30 +50,16 @@ describe('AddNewEventsAction', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
-          provide: getRepositoryToken(SubmissionEntity),
-          useValue: {
-            find: async () => {
-              return [
-                {
-                  submissionId: '123',
-                },
-              ];
-            },
-            update: async () => {
-              return;
-            },
-          },
-        },
-        {
           provide: getRepositoryToken(SupportedChainEntity),
           useValue: {
             findOne: async chainId => {
               return {
                 chainId,
-                latestBlock: 0,
+                latestBlock: 98,
                 network: 'eth',
               } as SupportedChainEntity;
             },
+            update: jest.fn().mockResolvedValue({}),
           },
         },
         ChainConfigService,

--- a/debridge_node/src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts
+++ b/debridge_node/src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts
@@ -144,4 +144,101 @@ describe('AddNewEventsAction', () => {
     );
     expect(processMock).toBeCalledTimes(1);
   });
+
+  describe('stale RPC response handling', () => {
+    let staleRpcService: AddNewEventsAction;
+    let staleWeb3;
+    let staleGetPastEventsMock;
+    let staleProcessMock;
+    let updateMock;
+
+    beforeEach(async () => {
+      staleProcessMock = jest.fn().mockResolvedValue({});
+      staleGetPastEventsMock = jest.fn().mockResolvedValue([]);
+      updateMock = jest.fn().mockResolvedValue({});
+
+      // Simulate stale RPC: getBlockNumber returns 100, but latestBlock in DB is 200
+      // This means fromBlock (200) > toBlock (99) after blockConfirmation
+      staleWeb3 = {
+        eth: {
+          setProvider: jest.fn().mockResolvedValue({}),
+          Contract: jest.fn().mockImplementation(() => {
+            return {
+              setProvider: jest.fn().mockResolvedValue({}),
+              getPastEvents: staleGetPastEventsMock,
+            };
+          }),
+          getBlockNumber: jest.fn().mockResolvedValue(100), // RPC returns block 100
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          {
+            provide: getRepositoryToken(SupportedChainEntity),
+            useValue: {
+              findOne: async () => {
+                return {
+                  chainId: 1,
+                  latestBlock: 200, // DB has synced to block 200 (ahead of RPC)
+                  network: 'eth',
+                } as SupportedChainEntity;
+              },
+              update: updateMock,
+            },
+          },
+          {
+            provide: ChainConfigService,
+            useValue: {
+              get(chainId) {
+                return {
+                  chainId,
+                  isSolana: false,
+                  maxBlockRange: 200,
+                  blockConfirmation: 1,
+                  debridgeAddr: 'debridgeAddr',
+                  providers: 'providers',
+                };
+              },
+            },
+          },
+          {
+            provide: Web3Service,
+            useValue: {
+              web3HttpProvider: jest.fn().mockImplementation(() => staleWeb3),
+            },
+          },
+          {
+            provide: SolanaReaderService,
+            useValue: {
+              syncTransactions: jest.fn().mockResolvedValue({}),
+            },
+          },
+          {
+            provide: SubmissionProcessingService,
+            useValue: {
+              process: staleProcessMock,
+            },
+          },
+          TransformService,
+          AddNewEventsAction,
+        ],
+      }).compile();
+      staleRpcService = module.get(AddNewEventsAction);
+    });
+
+    it('should reset latestBlock to toBlock when RPC returns stale block number', async () => {
+      await staleRpcService.action(1);
+
+      // Should NOT fetch events when fromBlock > toBlock
+      expect(staleGetPastEventsMock).not.toBeCalled();
+
+      // Should NOT process any submissions
+      expect(staleProcessMock).not.toBeCalled();
+
+      // Should update latestBlock to toBlock (99) to prevent massive resync
+      // toBlock = getBlockNumber(100) - blockConfirmation(1) = 99
+      expect(updateMock).toBeCalledWith(1, { latestBlock: 99 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When an RPC returns a stale block number causing `fromBlock > toBlock`, the current error handling in PR #80 queries the `submissions` table for the last event block and resets the chain's sync position to that block.

**The problem:** On chains with low debridge activity (like Zilliqa), the last event could be millions of blocks behind the current sync position, causing massive unnecessary resyncs. For example, on Zilliqa this caused a **2.9 million block resync** when the RPC momentarily returned stale data.

### Root Cause Analysis

The bug was discovered while debugging validator alerts showing Zilliqa lagging 2.8M blocks behind. Log analysis revealed:

| Time (UTC) | Event |
|------------|-------|
| 5:50:57 | Normal sync at block 18,653,005-18,653,006 |
| 5:51:06 | RPC returned stale data: `toBlock (18653005) < fromBlock (18653006)` |
| 5:51:06 | Error triggered: "Invalid block range" |
| 5:51:08 | Fallback logic queried DB: "Found last event block number: **15729178**" |
| 5:51:08 | Chain progress reset to 15,729,178 (~2.9M blocks behind) |

### The Fix

This PR changes the fallback behavior to use `toBlock` (the RPC's current confirmed block) instead of querying the submissions table. This is consistent with what the code already does when there are NO events:

```typescript
// Before (inconsistent behavior):
const newLatestBlock = lastEvent?.blockNumber ?? toBlock;

// After (always use toBlock):
await this.supportedChainRepository.update(chainId, { latestBlock: toBlock });
```

### Changes

- Remove unnecessary `SubmissionEntity` repository injection from `AddNewEventsAction`
- Simplify error handling to use `toBlock` as fallback
- Update tests to reflect the fix

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm test -- --testPathPattern="AddNewEventsAction"`)
- [ ] Deploy to staging validator and monitor for stale RPC responses
- [ ] Verify no massive resyncs occur when RPC returns stale block numbers

🤖 Generated with [Claude Code](https://claude.ai/code)