### PR TITLE
[codex] retry event scanning with next RPC provider

### DIFF
--- a/debridge_node/src/modules/chain/scanning/services/AddNewEventsAction.ts
+++ b/debridge_node/src/modules/chain/scanning/services/AddNewEventsAction.ts
@@ -12,6 +12,7 @@ import { TransformService } from './TransformService';
 import { ProcessNewTransferResultStatusEnum } from '../enums/ProcessNewTransferResultStatusEnum';
 import Contract from 'web3-eth-contract';
 import { SubmissionEntity } from '../../../../entities/SubmissionEntity';
+import { maskRpcUrl } from '../../../../utils/maskRpcUrl';
 
 @Injectable()
 export class AddNewEventsAction {
@@ -65,10 +66,8 @@ export class AddNewEventsAction {
     // Fetch chain details and initialize Web3 provider
     const supportedChain = await this.supportedChainRepository.findOne({ where: { chainId } });
     const chainConfig = this.chainConfigService.get(chainId) as EvmChainConfig;
-    const web3 = await this.web3Service.web3HttpProvider(chainConfig);
-    const gateContract = new web3.eth.Contract(deBridgeGateAbi as any, chainConfig.debridgeAddr);
-    // @ts-ignore
-    web3.eth.setProvider = gateContract.setProvider;
+    let web3 = await this.web3Service.web3HttpProvider(chainConfig);
+    let gateContract = this.createGateContract(web3, chainConfig);
 
     // Set block range: use provided values or defaults
     const toBlock = to ?? (await this.getConfirmedBlockNumber(web3, chainConfig.blockConfirmation));
@@ -78,9 +77,7 @@ export class AddNewEventsAction {
     // RPC returned garbage (0 or negative after subtracting confirmations) — skip entirely,
     // don't touch the DB progress to avoid resetting it.
     if (toBlock <= 0) {
-      logger.error(
-        `Invalid toBlock (${toBlock}) for chainId ${chainId}, RPC likely returned 0. Skipping scan.`
-      );
+      logger.error(`Invalid toBlock (${toBlock}) for chainId ${chainId}, RPC likely returned 0. Skipping scan.`);
       return;
     }
 
@@ -96,7 +93,7 @@ export class AddNewEventsAction {
       const safeBlock = Math.max(lastEvent?.blockNumber ?? 0, toBlock);
       logger.warn(
         `Stale RPC response detected: fromBlock (${fromBlock}) > toBlock (${toBlock}). ` +
-        `Resetting latestBlock to ${safeBlock} to prevent resync from old blocks.`
+          `Resetting latestBlock to ${safeBlock} to prevent resync from old blocks.`,
       );
       await this.supportedChainRepository.update(chainId, { latestBlock: safeBlock });
       return;
@@ -109,7 +106,10 @@ export class AddNewEventsAction {
         logger.warn(`latestBlock in db ${supportedChain.latestBlock} == lastBlockOfPage ${lastBlockOfPage}`);
         continue;
       }
-      const sentEvents = await this.getEvents(gateContract, fromBlock, lastBlockOfPage);
+      const eventPage = await this.getEventsWithProviderFailover(logger, chainConfig, gateContract, web3, fromBlock, lastBlockOfPage);
+      web3 = eventPage.web3;
+      gateContract = eventPage.gateContract;
+      const sentEvents = eventPage.sentEvents;
       logger.log(`sentEvents: ${JSON.stringify(sentEvents)}`);
       if (!sentEvents || sentEvents.length === 0) {
         logger.verbose(`Not found any events for ${chainId} ${fromBlock} - ${lastBlockOfPage}`);
@@ -166,5 +166,51 @@ export class AddNewEventsAction {
 
     /* get events */
     return await gateContract.getPastEvents('Sent', { fromBlock, toBlock });
+  }
+
+  private createGateContract(web3: Web3Custom, chainConfig: EvmChainConfig): Contract {
+    const gateContract = new web3.eth.Contract(deBridgeGateAbi as any, chainConfig.debridgeAddr);
+    // @ts-expect-error web3 setProvider is reassigned to the contract provider for existing call sites.
+    web3.eth.setProvider = gateContract.setProvider;
+    return gateContract;
+  }
+
+  private async getEventsWithProviderFailover(
+    logger: Logger,
+    chainConfig: EvmChainConfig,
+    initialGateContract: Contract,
+    initialWeb3: Web3Custom,
+    fromBlock: number,
+    toBlock: number,
+  ) {
+    let gateContract = initialGateContract;
+    let web3 = initialWeb3;
+    const failedProviders = new Set<string>();
+
+    while (true) {
+      try {
+        return {
+          sentEvents: await this.getEvents(gateContract, fromBlock, toBlock),
+          web3,
+          gateContract,
+        };
+      } catch (e) {
+        const failedProvider = web3.chainProvider;
+        failedProviders.add(failedProvider);
+        chainConfig.providers.setProviderStatus(failedProvider, false);
+        logger.error(`Provider ${maskRpcUrl(failedProvider)} failed to get events for range ` + `${fromBlock}-${toBlock}: ${e.message}`);
+
+        if (failedProviders.size >= chainConfig.providers.size()) {
+          throw e;
+        }
+
+        try {
+          web3 = await this.web3Service.web3HttpProvider(chainConfig, failedProviders);
+          gateContract = this.createGateContract(web3, chainConfig);
+        } catch {
+          throw e;
+        }
+      }
+    }
   }
 }

--- a/debridge_node/src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts
+++ b/debridge_node/src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts
@@ -28,6 +28,10 @@ async function buildService(config: {
   lastEventBlockNumber?: number | null;
   events?: any[];
   blockConfirmation?: number;
+  getPastEventsMock?: jest.Mock;
+  web3Mocks?: any[];
+  web3HttpProviderMock?: jest.Mock;
+  chainProviders?: any;
 }) {
   const isSolana = config.isSolana ?? false;
   const blockConfirmation = config.blockConfirmation ?? 1;
@@ -35,16 +39,15 @@ async function buildService(config: {
   const lastEventBlockNumber = config.lastEventBlockNumber ?? null;
 
   const updateMock = jest.fn().mockResolvedValue({});
-  const getPastEventsMock = jest.fn().mockResolvedValue(events);
+  const getPastEventsMock = config.getPastEventsMock ?? jest.fn().mockResolvedValue(events);
   const processMock = jest.fn().mockResolvedValue({});
   const syncTransactionsMock = jest.fn().mockResolvedValue({});
-  const submissionsFindOneMock = jest.fn().mockResolvedValue(
-    lastEventBlockNumber !== null
-      ? { blockNumber: lastEventBlockNumber, chainFrom: config.chainId }
-      : null,
-  );
+  const submissionsFindOneMock = jest
+    .fn()
+    .mockResolvedValue(lastEventBlockNumber !== null ? { blockNumber: lastEventBlockNumber, chainFrom: config.chainId } : null);
 
   const web3Mock = {
+    chainProvider: 'https://rpc-primary.debridge.com',
     eth: {
       setProvider: jest.fn(),
       Contract: jest.fn().mockImplementation(() => ({
@@ -84,7 +87,7 @@ async function buildService(config: {
               maxBlockRange: 200,
               blockConfirmation,
               debridgeAddr: 'debridgeAddr',
-              providers: 'providers',
+              providers: config.chainProviders ?? 'providers',
             };
           },
         },
@@ -92,7 +95,12 @@ async function buildService(config: {
       {
         provide: Web3Service,
         useValue: {
-          web3HttpProvider: jest.fn().mockImplementation(() => web3Mock),
+          web3HttpProvider:
+            config.web3HttpProviderMock ??
+            jest
+              .fn()
+              .mockImplementationOnce(() => config.web3Mocks?.[0] ?? web3Mock)
+              .mockImplementationOnce(() => config.web3Mocks?.[1] ?? config.web3Mocks?.[0] ?? web3Mock),
         },
       },
       {
@@ -111,7 +119,8 @@ async function buildService(config: {
   return {
     service: module.get(AddNewEventsAction),
     chainId: config.chainId,
-    web3: web3Mock,
+    web3: config.web3Mocks?.[0] ?? web3Mock,
+    web3Service: module.get(Web3Service),
     updateMock,
     getPastEventsMock,
     processMock,
@@ -157,8 +166,8 @@ describe('AddNewEventsAction', () => {
     it('scans correct block range and transforms events into submissions', async () => {
       const { service, chainId, getPastEventsMock, processMock, web3 } = await buildService({
         chainId: 1,
-        latestBlock: 98,       // fromBlock = 98
-        rpcBlockNumber: 100,   // toBlock = 100 - 1 = 99
+        latestBlock: 98, // fromBlock = 98
+        rpcBlockNumber: 100, // toBlock = 100 - 1 = 99
         events: [
           {
             returnValues: {
@@ -206,10 +215,105 @@ describe('AddNewEventsAction', () => {
           },
         ],
         chainId, // chainId
-        99,      // lastBlockOfPage
+        99, // lastBlockOfPage
         web3,
       );
       expect(processMock).toBeCalledTimes(1);
+    });
+
+    it('retries the same page with the next provider when historical log reads fail', async () => {
+      const firstGetPastEventsMock = jest.fn().mockRejectedValue(new Error('Archive requests require a personal token'));
+      const secondGetPastEventsMock = jest.fn().mockResolvedValue([]);
+      const firstWeb3 = {
+        chainProvider: 'https://recent-only-rpc.debridge.com',
+        eth: {
+          setProvider: jest.fn(),
+          Contract: jest.fn().mockImplementation(() => ({
+            setProvider: jest.fn(),
+            getPastEvents: firstGetPastEventsMock,
+          })),
+          getBlockNumber: jest.fn().mockResolvedValue(100),
+        },
+      };
+      const secondWeb3 = {
+        chainProvider: 'https://archive-rpc.debridge.com',
+        eth: {
+          setProvider: jest.fn(),
+          Contract: jest.fn().mockImplementation(() => ({
+            setProvider: jest.fn(),
+            getPastEvents: secondGetPastEventsMock,
+          })),
+          getBlockNumber: jest.fn().mockResolvedValue(100),
+        },
+      };
+      const chainProviders = {
+        setProviderStatus: jest.fn(),
+        size: jest.fn().mockReturnValue(2),
+      };
+
+      const { service, chainId, updateMock, processMock, web3Service } = await buildService({
+        chainId: 42161,
+        latestBlock: 98,
+        rpcBlockNumber: 100,
+        chainProviders,
+        web3Mocks: [firstWeb3, secondWeb3],
+      });
+
+      await service.action(chainId);
+
+      expect(firstGetPastEventsMock).toBeCalledWith('Sent', {
+        fromBlock: 98,
+        toBlock: 99,
+      });
+      expect(chainProviders.setProviderStatus).toBeCalledWith(firstWeb3.chainProvider, false);
+      expect(web3Service.web3HttpProvider).toHaveBeenNthCalledWith(1, expect.any(Object));
+      expect(web3Service.web3HttpProvider).toHaveBeenNthCalledWith(2, expect.any(Object), new Set([firstWeb3.chainProvider]));
+      expect(secondGetPastEventsMock).toBeCalledWith('Sent', {
+        fromBlock: 98,
+        toBlock: 99,
+      });
+      expect(updateMock).toBeCalledWith(chainId, { latestBlock: 99 });
+      expect(processMock).not.toBeCalled();
+    });
+
+    it('preserves the original event read error when failover cannot acquire another provider', async () => {
+      const originalError = new Error('Archive requests require a personal token');
+      const failoverError = new Error("Cann't connect to any provider");
+      const getPastEventsMock = jest.fn().mockRejectedValue(originalError);
+      const web3 = {
+        chainProvider: 'https://recent-only-rpc.debridge.com',
+        eth: {
+          setProvider: jest.fn(),
+          Contract: jest.fn().mockImplementation(() => ({
+            setProvider: jest.fn(),
+            getPastEvents: getPastEventsMock,
+          })),
+          getBlockNumber: jest.fn().mockResolvedValue(100),
+        },
+      };
+      const web3HttpProviderMock = jest.fn().mockResolvedValueOnce(web3).mockRejectedValueOnce(failoverError);
+      const chainProviders = {
+        setProviderStatus: jest.fn(),
+        size: jest.fn().mockReturnValue(2),
+      };
+
+      const { service, chainId } = await buildService({
+        chainId: 42161,
+        latestBlock: 98,
+        rpcBlockNumber: 100,
+        chainProviders,
+        web3HttpProviderMock,
+      });
+
+      let thrownError: Error;
+      try {
+        await service.process(chainId);
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBe(originalError);
+      expect(web3HttpProviderMock).toBeCalledTimes(2);
     });
   });
 

--- a/debridge_node/src/modules/web3/services/Web3Service.ts
+++ b/debridge_node/src/modules/web3/services/Web3Service.ts
@@ -7,7 +7,10 @@ import { maskRpcUrl, maskRpcUrls } from '../../../utils/maskRpcUrl';
 import { DEFAULT_WEB3_TIMEOUT_MS, parsePositiveInt } from '../../../utils/parsePositiveInt';
 
 export class Web3Custom extends Web3 {
-  constructor(readonly chainProvider: string, httpProvider) {
+  constructor(
+    readonly chainProvider: string,
+    httpProvider,
+  ) {
     super(httpProvider);
   }
 }
@@ -59,9 +62,13 @@ export class Web3Service {
     return httpProvider;
   }
 
-  async web3HttpProvider(chainConfig: EvmChainConfig): Promise<Web3Custom> {
+  async web3HttpProvider(chainConfig: EvmChainConfig, excludedProviders = new Set<string>()): Promise<Web3Custom> {
     const chainProvider = chainConfig.providers;
-    for (const provider of [...chainProvider.getNotFailedProviders(), ...chainProvider.getFailedProviders()]) {
+    const providers = [...chainProvider.getNotFailedProviders(), ...chainProvider.getFailedProviders()].filter(
+      provider => !excludedProviders.has(provider),
+    );
+
+    for (const provider of providers) {
       if (this.providersMap.has(provider)) {
         const web3 = this.providersMap.get(provider);
         const isWorking = await this.checkConnectionHttpProvider(web3);
@@ -122,12 +129,10 @@ export class Web3Service {
       });
       const web3 = new Web3Custom(provider, httpProvider);
       const contractInstance = new web3.eth.Contract(deBridgeGateAbi as any, chainConfig.debridgeAddr);
-      // @ts-ignore
+      // @ts-expect-error web3 setProvider is reassigned to the contract provider for existing call sites.
       web3.eth.setProvider = contractInstance.setProvider;
 
-      const contractChainId = Number(
-        await contractInstance.methods.getChainId().call(),
-      );
+      const contractChainId = Number(await contractInstance.methods.getChainId().call());
       if (contractChainId !== chainProvider.getChainId()) {
         this.logger.error(`Checking correct RPC from config is failed (in config ${chainProvider.getChainId()} in contract ${contractChainId})`);
         process.exit(1);


### PR DESCRIPTION
## Summary

Fixes #89.

This adds page-level provider failover for EVM event scanning. If the selected RPC provider passes basic health checks but fails `getPastEvents('Sent', { fromBlock, toBlock })`, the scanner now marks that provider inactive for the current chain, excludes it from the current page retry, and retries the same block page with the next configured provider.

## Root Cause

`Web3Service.web3HttpProvider()` selected providers using `eth_getBlockNumber` and chain-id validation. Some providers can pass those checks while still rejecting historical log/archive requests. When `AddNewEventsAction` later called `getPastEvents`, the error bubbled out of the scan, the provider stayed active/cached, and the next scan tick selected the same provider again.

## What Changed

- Added an optional provider exclusion set to `Web3Service.web3HttpProvider()`.
- Added `getPastEvents` retry/failover inside `AddNewEventsAction` for the same `{ fromBlock, toBlock }` page.
- Preserved the original event-read error if fallback provider acquisition fails.
- Kept `latestBlock` advancement behind successful page reads.
- Added regression tests for provider failover and original-error preservation.

## Validation

- `npm test -- --runInBand` — 146 passed
- `npm run build` — passed
- `npx eslint src/modules/chain/scanning/services/AddNewEventsAction.ts src/modules/chain/scanning/services/tests/AddNewEventsAction.spec.ts src/modules/web3/services/Web3Service.ts` — passed

`npm run lint` still fails on pre-existing lint/prettier issues in unrelated files, including SolanaReaderService tests, Web3Service tests, utility tests, and a few services. The three files touched by this PR lint cleanly.
